### PR TITLE
[PR] 회원가입 기능 구현, 모집글 생성 구현

### DIFF
--- a/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/aggregate/SeekingMemberPost.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/aggregate/SeekingMemberPost.java
@@ -1,0 +1,152 @@
+package org.omoknoone.omokhub.seekingmemberpost.command.aggregate;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "SEEKING_MEMBER_POST")
+public class SeekingMemberPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int seekingMemberPostId;
+    @Column
+    private String title;
+    @Column
+    private int seekingMember;
+    @Column
+    private LocalDate startDate;
+    @Column
+    private LocalDate endDate;
+    @Column
+    private String techStack;
+    @Column
+    private String content;
+    @Column
+    @CreationTimestamp
+    private LocalDateTime lastModifiedDate;
+    @Column
+    private boolean isSeeking;
+    @Column
+    private String memberId;
+    @Column
+    private boolean isDeleted;
+    @Column
+    private int projectId;
+
+    public SeekingMemberPost() {
+    }
+
+    public SeekingMemberPost(int seekingMemberPostId, String title, int seekingMember, LocalDate startDate, LocalDate endDate, String techStack, String content, LocalDateTime lastModifiedDate, boolean isSeeking, String memberId, boolean isDeleted, int projectId) {
+        this.seekingMemberPostId = seekingMemberPostId;
+        this.title = title;
+        this.seekingMember = seekingMember;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.techStack = techStack;
+        this.content = content;
+        this.lastModifiedDate = lastModifiedDate;
+        this.isSeeking = isSeeking;
+        this.memberId = memberId;
+        this.isDeleted = isDeleted;
+        this.projectId = projectId;
+    }
+
+    public int getSeekingMemberPostId() {
+        return seekingMemberPostId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getSeekingMember() {
+        return seekingMember;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public String getTechStack() {
+        return techStack;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public LocalDateTime getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public boolean isSeeking() {
+        return isSeeking;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public int getProjectId() {
+        return projectId;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setSeekingMember(int seekingMember) {
+        this.seekingMember = seekingMember;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public void setTechStack(String techStack) {
+        this.techStack = techStack;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setMemberId(String memberId) {
+        this.memberId = memberId;
+    }
+
+    public void setProjectId(int projectId) {
+        this.projectId = projectId;
+    }
+
+    @Override
+    public String toString() {
+        return "SeekingMemberPost{" +
+                "seekingMemberPostId=" + seekingMemberPostId +
+                ", title='" + title + '\'' +
+                ", seekingMember=" + seekingMember +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                ", techStack='" + techStack + '\'' +
+                ", content='" + content + '\'' +
+                ", lastModifiedDate=" + lastModifiedDate +
+                ", isSeeking=" + isSeeking +
+                ", memberId='" + memberId + '\'' +
+                ", isDeleted=" + isDeleted +
+                ", projectId=" + projectId +
+                '}';
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/controller/SeekingMemberPostController.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/controller/SeekingMemberPostController.java
@@ -1,0 +1,52 @@
+package org.omoknoone.omokhub.seekingmemberpost.command.controller;
+
+import org.modelmapper.ModelMapper;
+import org.omoknoone.omokhub.seekingmemberpost.command.dto.SeekingMemberPostDTO;
+import org.omoknoone.omokhub.seekingmemberpost.command.service.SeekingMemberPostService;
+import org.omoknoone.omokhub.seekingmemberpost.command.vo.RequestSeekingMemberPost;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@RestController
+@RequestMapping("/seekingmemberpost/seekingmemberpost")
+public class SeekingMemberPostController {
+
+    private final SeekingMemberPostService seekingMemberPostService;
+    private final ModelMapper modelMapper;
+
+    /* 설명. 로그 사용하기, github에 올릴 때 주석*/
+    Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    public SeekingMemberPostController(SeekingMemberPostService seekingMemberPostService, ModelMapper modelMapper) {
+        this.seekingMemberPostService = seekingMemberPostService;
+        this.modelMapper = modelMapper;
+    }
+
+
+
+    @PostMapping("/newpost")
+    public ResponseEntity<Map<String, Integer>> newPost(@RequestBody RequestSeekingMemberPost seekingMemberPost) {
+
+        SeekingMemberPostDTO seekingMemberPostDTO = modelMapper.map(seekingMemberPost, SeekingMemberPostDTO.class);
+
+        int postId = seekingMemberPostService.newPost(seekingMemberPostDTO);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new HashMap<>() {{
+                    put("seekingMemberId", postId);
+                }});
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/dto/SeekingMemberPostDTO.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/dto/SeekingMemberPostDTO.java
@@ -1,0 +1,152 @@
+package org.omoknoone.omokhub.seekingmemberpost.command.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SeekingMemberPostDTO {
+    private int seekingMemberPostId;
+    private String title;
+    private int seekingMember;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<String> techStack;
+    private String content;
+    private LocalDateTime lastModifiedDate;
+    private boolean isSeeking;
+    private String memberId;
+    private boolean isDeleted;
+    private int projectId;
+
+    public SeekingMemberPostDTO() {
+    }
+
+    public SeekingMemberPostDTO(int seekingMemberPostId, String title, int seekingMember, LocalDate startDate, LocalDate endDate, List<String> techStack, String content, LocalDateTime lastModifiedDate, boolean isSeeking, String memberId, boolean isDeleted, int projectId) {
+        this.seekingMemberPostId = seekingMemberPostId;
+        this.title = title;
+        this.seekingMember = seekingMember;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.techStack = techStack;
+        this.content = content;
+        this.lastModifiedDate = lastModifiedDate;
+        this.isSeeking = isSeeking;
+        this.memberId = memberId;
+        this.isDeleted = isDeleted;
+        this.projectId = projectId;
+    }
+
+    public int getSeekingMemberPostId() {
+        return seekingMemberPostId;
+    }
+
+    public void setSeekingMemberPostId(int seekingMemberPostId) {
+        this.seekingMemberPostId = seekingMemberPostId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public int getSeekingMember() {
+        return seekingMember;
+    }
+
+    public void setSeekingMember(int seekingMember) {
+        this.seekingMember = seekingMember;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public List<String> getTechStack() {
+        return techStack;
+    }
+
+    public void setTechStack(List<String> techStack) {
+        this.techStack = techStack;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public LocalDateTime getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public void setLastModifiedDate(LocalDateTime lastModifiedDate) {
+        this.lastModifiedDate = lastModifiedDate;
+    }
+
+    public boolean isSeeking() {
+        return isSeeking;
+    }
+
+    public void setSeeking(boolean seeking) {
+        isSeeking = seeking;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(String memberId) {
+        this.memberId = memberId;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        isDeleted = deleted;
+    }
+
+    public int getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(int projectId) {
+        this.projectId = projectId;
+    }
+
+    @Override
+    public String toString() {
+        return "SeekingMemberPostDTO{" +
+                "seekingMemberPostId=" + seekingMemberPostId +
+                ", title='" + title + '\'' +
+                ", seekingMember=" + seekingMember +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                ", techStack=" + techStack +
+                ", content='" + content + '\'' +
+                ", lastModifiedDate=" + lastModifiedDate +
+                ", isSeeking=" + isSeeking +
+                ", memberId='" + memberId + '\'' +
+                ", isDeleted=" + isDeleted +
+                ", projectId=" + projectId +
+                '}';
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/repository/SeekingMemberPostRepository.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/repository/SeekingMemberPostRepository.java
@@ -1,0 +1,8 @@
+package org.omoknoone.omokhub.seekingmemberpost.command.repository;
+
+import org.omoknoone.omokhub.seekingmemberpost.command.aggregate.SeekingMemberPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeekingMemberPostRepository extends JpaRepository<SeekingMemberPost, Integer> {
+
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/service/SeekingMemberPostService.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/service/SeekingMemberPostService.java
@@ -1,0 +1,7 @@
+package org.omoknoone.omokhub.seekingmemberpost.command.service;
+
+import org.omoknoone.omokhub.seekingmemberpost.command.dto.SeekingMemberPostDTO;
+
+public interface SeekingMemberPostService {
+    int newPost(SeekingMemberPostDTO seekingMemberPostDTO);
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/service/SeekingMemberPostServiceImpl.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/service/SeekingMemberPostServiceImpl.java
@@ -1,0 +1,64 @@
+package org.omoknoone.omokhub.seekingmemberpost.command.service;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.omokhub.seekingmemberpost.command.aggregate.SeekingMemberPost;
+import org.omoknoone.omokhub.seekingmemberpost.command.dto.SeekingMemberPostDTO;
+import org.omoknoone.omokhub.seekingmemberpost.command.repository.SeekingMemberPostRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class SeekingMemberPostServiceImpl implements SeekingMemberPostService {
+
+    private final ModelMapper modelMapper;
+    private final SeekingMemberPostRepository seekingMemberPostRepository;
+
+    Logger logger = LoggerFactory.getLogger(getClass());
+    @Autowired
+    public SeekingMemberPostServiceImpl(ModelMapper modelMapper, SeekingMemberPostRepository seekingMemberPostRepository) {
+        this.modelMapper = modelMapper;
+        this.seekingMemberPostRepository = seekingMemberPostRepository;
+    }
+
+    @Override
+    public int newPost(SeekingMemberPostDTO seekingMemberPostDTO) {
+        logger.info("[LOGGER] newSeekingMemberPost techStack: {}", seekingMemberPostDTO.getTechStack());
+
+        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        SeekingMemberPost seekingMemberPost = modelMapper.map(seekingMemberPostDTO, SeekingMemberPost.class);
+
+        List<String> techStackList = seekingMemberPostDTO.getTechStack();
+
+        StringBuilder sb = new StringBuilder();
+        for (String s : techStackList) {
+            sb.append(s + ", ");
+        }
+        sb.delete(sb.length() - 2, sb.length());
+        String techStack = sb.toString();
+
+        seekingMemberPost.setTechStack(techStack);
+
+
+        seekingMemberPostRepository.save(seekingMemberPost);
+
+        logger.info("[LOGGER] after 모집글 생성 후 ID 값: {}", seekingMemberPost.getSeekingMemberPostId());
+
+        return seekingMemberPost.getSeekingMemberPostId();
+    }
+
+
+//    @Transactional
+//    public void signUp(SeekingMemberPostDTO newMember) {
+//        logger.info("[LOGGER] newMember: {}", newMember);
+//
+//        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+//        memberRepository.save(modelMapper.map(newMember, SeekingMemberPost.class));
+//    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/vo/RequestSeekingMemberPost.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/seekingmemberpost/command/vo/RequestSeekingMemberPost.java
@@ -1,0 +1,140 @@
+package org.omoknoone.omokhub.seekingmemberpost.command.vo;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class RequestSeekingMemberPost {
+    private int seekingMemberPostId;
+    private String title;
+    private int seekingMember;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<String> techStack;
+    private String content;
+    private boolean isSeeking;
+    private String memberId;
+    private boolean isDeleted;
+    private int projectId;
+
+    public RequestSeekingMemberPost() {
+    }
+
+    public RequestSeekingMemberPost(int seekingMemberPostId, String title, int seekingMember, LocalDate startDate, LocalDate endDate, List<String> techStack, String content, boolean isSeeking, String memberId, boolean isDeleted, int projectId) {
+        this.seekingMemberPostId = seekingMemberPostId;
+        this.title = title;
+        this.seekingMember = seekingMember;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.techStack = techStack;
+        this.content = content;
+        this.isSeeking = isSeeking;
+        this.memberId = memberId;
+        this.isDeleted = isDeleted;
+        this.projectId = projectId;
+    }
+
+    public int getSeekingMemberPostId() {
+        return seekingMemberPostId;
+    }
+
+    public void setSeekingMemberPostId(int seekingMemberPostId) {
+        this.seekingMemberPostId = seekingMemberPostId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public int getSeekingMember() {
+        return seekingMember;
+    }
+
+    public void setSeekingMember(int seekingMember) {
+        this.seekingMember = seekingMember;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public List<String> getTechStack() {
+        return techStack;
+    }
+
+    public void setTechStack(List<String> techStack) {
+        this.techStack = techStack;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public boolean isSeeking() {
+        return isSeeking;
+    }
+
+    public void setSeeking(boolean seeking) {
+        isSeeking = seeking;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(String memberId) {
+        this.memberId = memberId;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        isDeleted = deleted;
+    }
+
+    public int getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(int projectId) {
+        this.projectId = projectId;
+    }
+
+    @Override
+    public String toString() {
+        return "RequestSeekingMemberPost{" +
+                "seekingMemberPostId=" + seekingMemberPostId +
+                ", title='" + title + '\'' +
+                ", seekingMember=" + seekingMember +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                ", techStack=" + techStack +
+                ", content='" + content + '\'' +
+                ", isSeeking=" + isSeeking +
+                ", memberId='" + memberId + '\'' +
+                ", isDeleted=" + isDeleted +
+                ", projectId=" + projectId +
+                '}';
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/aggregate/Member.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/aggregate/Member.java
@@ -1,0 +1,141 @@
+package org.omoknoone.omokhub.user.command.aggregate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "MEMBER")
+public class Member {
+
+    @Id
+    @Column
+    private String memberId;
+    @Column
+    private String name;
+    @Column
+    private String nickname;
+    @Column
+    private String password;
+    @Column
+    private String email;
+    @Column
+    private String phoneNum;
+    @Column
+    private String address;
+    @Column
+    private String birthday;
+    @Column
+    private String signUpDate;
+    @Column(name = "IS_WITHDRAW")
+    private boolean isWithdraw;
+
+    public Member() {
+    }
+
+    public Member(String memberId, String name, String nickname, String password, String email, String phoneNum, String address, String birthday, String singUpDate, boolean isWithdraw) {
+        this.memberId = memberId;
+        this.name = name;
+        this.nickname = nickname;
+        this.password = password;
+        this.email = email;
+        this.phoneNum = phoneNum;
+        this.address = address;
+        this.birthday = birthday;
+        this.signUpDate = singUpDate;
+        this.isWithdraw = isWithdraw;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPhoneNum() {
+        return phoneNum;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getBirthday() {
+        return birthday;
+    }
+
+    public String getSignUpDate() {
+        return signUpDate;
+    }
+
+    public boolean isWithdraw() {
+        return isWithdraw;
+    }
+
+    public void setMemberId(String memberId) {
+        this.memberId = memberId;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setPhoneNum(String phoneNum) {
+        this.phoneNum = phoneNum;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public void setBirthday(String birthday) {
+        this.birthday = birthday;
+    }
+
+    public void setSignUpDate(String signUpDate) {
+        this.signUpDate = signUpDate;
+    }
+
+    @Override
+    public String toString() {
+        return "Member{" +
+                "memberId=" + memberId +
+                ", name='" + name + '\'' +
+                ", nickname='" + nickname + '\'' +
+                ", password='" + password + '\'' +
+                ", email='" + email + '\'' +
+                ", phoneNum='" + phoneNum + '\'' +
+                ", address='" + address + '\'' +
+                ", birthday='" + birthday + '\'' +
+                ", singUpDate='" + signUpDate + '\'' +
+                ", isWithdraw=" + isWithdraw +
+                '}';
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/aggregate/Member.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/aggregate/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "MEMBER")
@@ -27,6 +28,7 @@ public class Member {
     @Column
     private String birthday;
     @Column
+    @CreationTimestamp
     private String signUpDate;
     @Column(name = "IS_WITHDRAW")
     private boolean isWithdraw;

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/controller/MemberController.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/controller/MemberController.java
@@ -1,0 +1,46 @@
+package org.omoknoone.omokhub.user.command.controller;
+
+import org.modelmapper.ModelMapper;
+import org.omoknoone.omokhub.user.command.dto.MemberDTO;
+import org.omoknoone.omokhub.user.command.service.MemberService;
+import org.omoknoone.omokhub.user.command.vo.RequestMember;
+import org.omoknoone.omokhub.user.command.vo.ResponseMember;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/user/member")
+public class MemberController {
+
+    private final MemberService memberService;
+    private final ModelMapper modelMapper;
+
+    /* 설명. 로그 사용하기, github에 올릴 때 주석*/
+    Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    public MemberController(MemberService memberService, ModelMapper modelMapper) {
+        this.memberService = memberService;
+        this.modelMapper = modelMapper;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<ResponseMember> signUp(@RequestBody RequestMember member) {
+
+        MemberDTO memberDTO = modelMapper.map(member, MemberDTO.class);
+
+        memberService.signUp(memberDTO);
+
+        ResponseMember responseMember = modelMapper.map(memberDTO, ResponseMember.class);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseMember);
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/dto/MemberDTO.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/dto/MemberDTO.java
@@ -1,0 +1,129 @@
+package org.omoknoone.omokhub.user.command.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class MemberDTO {
+    private String memberId;
+    private String name;
+    private String nickname;
+    private String password;
+    private String email;
+    private String phoneNum;
+    private String address;
+    private LocalDate birthday;
+    private LocalDateTime signUpDate;
+    private boolean isWithdraw;
+
+    public MemberDTO() {
+    }
+
+    public MemberDTO(String memberId, String name, String nickname, String password, String email, String phoneNum, String address, LocalDate birthday, LocalDateTime signUpDate, boolean isWithdraw) {
+        this.memberId = memberId;
+        this.name = name;
+        this.nickname = nickname;
+        this.password = password;
+        this.email = email;
+        this.phoneNum = phoneNum;
+        this.address = address;
+        this.birthday = birthday;
+        this.signUpDate = signUpDate;
+        this.isWithdraw = isWithdraw;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(String memberId) {
+        this.memberId = memberId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhoneNum() {
+        return phoneNum;
+    }
+
+    public void setPhoneNum(String phoneNum) {
+        this.phoneNum = phoneNum;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+    public LocalDateTime getSignUpDate() {
+        return signUpDate;
+    }
+
+    public void setSignUpDate(LocalDateTime signUpDate) {
+        this.signUpDate = signUpDate;
+    }
+
+    public boolean isWithdraw() {
+        return isWithdraw;
+    }
+
+    public void setWithdraw(boolean withdraw) {
+        isWithdraw = withdraw;
+    }
+
+    @Override
+    public String toString() {
+        return "Member{" +
+                "memberId='" + memberId + '\'' +
+                ", name='" + name + '\'' +
+                ", nickname='" + nickname + '\'' +
+                ", password='" + password + '\'' +
+                ", email='" + email + '\'' +
+                ", phoneNum='" + phoneNum + '\'' +
+                ", address='" + address + '\'' +
+                ", birthday=" + birthday +
+                ", signUpDate=" + signUpDate +
+                ", isWithdraw=" + isWithdraw +
+                '}';
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/repository/MemberRepository.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package org.omoknoone.omokhub.user.command.repository;
+
+import org.omoknoone.omokhub.user.command.aggregate.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, String> {
+
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/service/MemberService.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/service/MemberService.java
@@ -1,0 +1,8 @@
+package org.omoknoone.omokhub.user.command.service;
+
+import org.omoknoone.omokhub.user.command.dto.MemberDTO;
+
+public interface MemberService {
+
+    void signUp(MemberDTO memberDTO);
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/service/MemberServiceImpl.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/service/MemberServiceImpl.java
@@ -32,12 +32,7 @@ public class MemberServiceImpl implements MemberService {
     public void signUp(MemberDTO newMember) {
         logger.info("[LOGGER] newMember: {}", newMember);
 
-        LocalDateTime now = LocalDateTime.now();
-
-        newMember.setSignUpDate(now);
-
         modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
         memberRepository.save(modelMapper.map(newMember, Member.class));
-
     }
 }

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/service/MemberServiceImpl.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/service/MemberServiceImpl.java
@@ -1,0 +1,43 @@
+package org.omoknoone.omokhub.user.command.service;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.omoknoone.omokhub.user.command.aggregate.Member;
+import org.omoknoone.omokhub.user.command.dto.MemberDTO;
+import org.omoknoone.omokhub.user.command.repository.MemberRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Service
+public class MemberServiceImpl implements MemberService {
+
+    private final ModelMapper modelMapper;
+    private final MemberRepository memberRepository;
+
+    Logger logger = LoggerFactory.getLogger(getClass());
+    @Autowired
+    public MemberServiceImpl(ModelMapper modelMapper, MemberRepository memberRepository) {
+        this.modelMapper = modelMapper;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void signUp(MemberDTO newMember) {
+        logger.info("[LOGGER] newMember: {}", newMember);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        newMember.setSignUpDate(now);
+
+        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        memberRepository.save(modelMapper.map(newMember, Member.class));
+
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/vo/RequestMember.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/vo/RequestMember.java
@@ -1,0 +1,106 @@
+package org.omoknoone.omokhub.user.command.vo;
+
+import java.time.LocalDate;
+
+public class RequestMember {
+    private String memberId;
+    private String name;
+    private String nickname;
+    private String password;
+    private String email;
+    private String phoneNum;
+    private String address;
+    private LocalDate birthday;
+
+    public RequestMember() {
+    }
+
+    public RequestMember(String memberId, String name, String nickname, String password, String email, String phoneNum, String address, LocalDate birthday) {
+        this.memberId = memberId;
+        this.name = name;
+        this.nickname = nickname;
+        this.password = password;
+        this.email = email;
+        this.phoneNum = phoneNum;
+        this.address = address;
+        this.birthday = birthday;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(String memberId) {
+        this.memberId = memberId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhoneNum() {
+        return phoneNum;
+    }
+
+    public void setPhoneNum(String phoneNum) {
+        this.phoneNum = phoneNum;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public LocalDate getBirthday() {
+        return birthday;
+    }
+
+    public void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+    @Override
+    public String toString() {
+        return "RequestMember{" +
+                "memberId='" + memberId + '\'' +
+                ", name='" + name + '\'' +
+                ", nickname='" + nickname + '\'' +
+                ", password='" + password + '\'' +
+                ", email='" + email + '\'' +
+                ", phoneNum='" + phoneNum + '\'' +
+                ", address='" + address + '\'' +
+                ", birthday=" + birthday +
+                '}';
+    }
+}

--- a/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/vo/ResponseMember.java
+++ b/OmokHub/src/main/java/org/omoknoone/omokhub/user/command/vo/ResponseMember.java
@@ -1,0 +1,49 @@
+package org.omoknoone.omokhub.user.command.vo;
+
+public class ResponseMember {
+    private String memberId;
+    private String name;
+    private String nickname;
+
+    public ResponseMember() {
+    }
+
+    public ResponseMember(String memberId, String name, String nickname) {
+        this.memberId = memberId;
+        this.name = name;
+        this.nickname = nickname;
+    }
+
+    public String getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(String memberId) {
+        this.memberId = memberId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    @Override
+    public String toString() {
+        return "ResponseMember{" +
+                "memberId='" + memberId + '\'' +
+                ", name='" + name + '\'' +
+                ", nickname='" + nickname + '\'' +
+                '}';
+    }
+}


### PR DESCRIPTION
### 이 PR이 해결하는 문제

비회원이 회원가입을 통해 회원이 될 수 있다
모집글 추가 기능 개발

### 변경 내용

- 회원에 관한 JPA 패키지 생성
- REST 컨트롤러를 생성하여 회원 가입을 처리하는 엔드포인트 구현
- 필요한 서비스 및 리포지토리 클래스를 작성하여 회원 가입 로직 구현
- 클라이언트로부터 받은 회원 정보를 데이터베이스에 저장

- 모집글을 생성하는 REST API 엔드포인트를 구현
- HTTP POST 요청을 수신하며, 클라이언트가 전달한 데이터를 기반으로 새로운 모집글을 생성

### 테스트
- [x] 회원가입 테스트
- [x] 모집글 생성 테스트

### 관련 이슈
Closes #63 
Closes #64 